### PR TITLE
Add weather icons to weather bar

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "partyserver": "0.0.66",
     "partysocket": "1.1.3",
     "react": "18.3.1",
-    "react-dom": "18.3.1"
+    "react-dom": "18.3.1",
+    "react-icons": "^4.11.0"
   },
   "devDependencies": {
     "@types/react": "18.3.12",

--- a/src/client/index.tsx
+++ b/src/client/index.tsx
@@ -1,6 +1,20 @@
 import "./styles.css";
 
 import React, { useEffect, useRef, useState } from "react";
+import type { IconType } from "react-icons";
+import {
+  WiDaySunny,
+  WiDayCloudy,
+  WiCloud,
+  WiFog,
+  WiSprinkle,
+  WiSleet,
+  WiRain,
+  WiSnow,
+  WiShowers,
+  WiSnowWind,
+  WiThunderstorm,
+} from "react-icons/wi";
 import { createRoot } from "react-dom/client";
 import createGlobe from "cobe";
 import usePartySocket from "partysocket/react";
@@ -32,6 +46,7 @@ function App() {
   const [weather, setWeather] = useState<{
     temperature: number;
     description: string;
+    Icon: IconType;
   } | null>(null);
 
   useEffect(() => {
@@ -83,10 +98,41 @@ function App() {
           96: "Thunderstorm",
           99: "Thunderstorm",
         };
+        const iconMap: Record<number, IconType> = {
+          0: WiDaySunny,
+          1: WiDaySunny,
+          2: WiDayCloudy,
+          3: WiCloud,
+          45: WiFog,
+          48: WiFog,
+          51: WiSprinkle,
+          53: WiSprinkle,
+          55: WiSprinkle,
+          56: WiSleet,
+          57: WiSleet,
+          61: WiRain,
+          63: WiRain,
+          65: WiRain,
+          66: WiRain,
+          67: WiRain,
+          71: WiSnow,
+          73: WiSnow,
+          75: WiSnow,
+          77: WiSnow,
+          80: WiShowers,
+          81: WiShowers,
+          82: WiShowers,
+          85: WiSnowWind,
+          86: WiSnowWind,
+          95: WiThunderstorm,
+          96: WiThunderstorm,
+          99: WiThunderstorm,
+        };
 
         setWeather({
           temperature: weatherData.current_weather.temperature,
           description: descriptions[code] || "Unknown",
+          Icon: iconMap[code] || WiDaySunny,
         });
       } catch (err) {
         console.error(err);
@@ -231,6 +277,7 @@ function App() {
       {location && weather && (
         <div className="weather-bar">
           {location.city && <span>{location.city}&nbsp;</span>}
+          <weather.Icon className="weather-icon" />
           <span>
             {weather.temperature.toFixed(1)}°C, {weather.description}
           </span>

--- a/src/client/styles.css
+++ b/src/client/styles.css
@@ -115,3 +115,18 @@ a {
   border-radius: 8px;
   font-size: 0.9rem;
 }
+
+.weather-icon {
+  display: inline-block;
+  margin-right: 0.25rem;
+  animation: weather-spin 6s linear infinite;
+}
+
+@keyframes weather-spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}


### PR DESCRIPTION
## Summary
- add `react-icons` to dependencies
- map Open-Meteo codes to Weather Icons
- show animated weather icon in the weather bar

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npx esbuild src/client/index.tsx --bundle --outdir=public/dist --splitting --sourcemap --format=esm` *(fails: 403 Forbidden)*
- `npm run check` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684928cf25d88329ba690cea8b8c7451